### PR TITLE
Update news-service-k8s.yaml

### DIFF
--- a/kubernetess/news-service-k8s.yaml
+++ b/kubernetess/news-service-k8s.yaml
@@ -1200,7 +1200,8 @@ metadata:
   name: news-service-fanout
 spec:
   rules:
-  - http:
+  - host: localhost
+    http:
       paths:
       - backend:
           serviceName: news-manager
@@ -1231,7 +1232,8 @@ metadata:
   name: news-service-rabbit
 spec:
   rules:
-  - http:
+  - host: localhost
+    http:
       paths:
       - backend:
           serviceName: rabbitmq


### PR DESCRIPTION
Hi dude

This way you could target http://localhost/uaa/v1/api/docs/ui#/ directly, instead of using the load balancer's IP
In a nearby future, the "localhost" hardcoded value could be changed with a Helm value with our DNS

What you think bro?